### PR TITLE
Cast :perfdata to a float so that integer/long values can be handled

### DIFF
--- a/src/riemann_flapjack_output/core.clj
+++ b/src/riemann_flapjack_output/core.clj
@@ -17,7 +17,7 @@
   "
   (comp
       (partial merge default-event-fields)
-      #(assoc % :perfdata (format "metric=%f" (:perfdata %))) ; flapjack wants perfdata as nagios string
+      #(assoc % :perfdata (format "metric=%f" (float (:perfdata %)))) ; flapjack wants perfdata as nagios string
       #(assoc % :time (int (:time %))) ; flapjack wants time as integer
       #(select-keys % allowed-event-fields) ; flapjack doesn't like fields it doesn't know
       #(rename-keys % default-rename-keys-map)

--- a/src/riemann_flapjack_output/core.clj
+++ b/src/riemann_flapjack_output/core.clj
@@ -17,7 +17,7 @@
   "
   (comp
       (partial merge default-event-fields)
-      #(assoc % :perfdata (format "metric=%f" (float (:perfdata %)))) ; flapjack wants perfdata as nagios string
+      #(if (nil? (:perfdata %)) % (assoc % :perfdata (format "metric=%f" (float (:perfdata %))))) ; flapjack wants perfdata as nagios string, convert if present
       #(assoc % :time (int (:time %))) ; flapjack wants time as integer
       #(select-keys % allowed-event-fields) ; flapjack doesn't like fields it doesn't know
       #(rename-keys % default-rename-keys-map)


### PR DESCRIPTION
When the :metric (renamed to :perfdata) contains an integer/long the conversion to a nagios string throws an IllegalFormatConversionException exception:

```
WARN [2015-09-24 21:37:55,616] Thread-12 - riemann.config - clojure.core$partial$fn__4228@84c9500 threw
java.util.IllegalFormatConversionException: f != java.lang.Integer
        at java.util.Formatter$FormatSpecifier.failConversion(Formatter.java:4302)
        at java.util.Formatter$FormatSpecifier.printFloat(Formatter.java:2806)
        at java.util.Formatter$FormatSpecifier.print(Formatter.java:2753)
        at java.util.Formatter.format(Formatter.java:2520)
        at java.util.Formatter.format(Formatter.java:2455)
        at java.lang.String.format(String.java:2940)
        at clojure.core$format.doInvoke(core.clj:5284)
        at clojure.lang.RestFn.invoke(RestFn.java:423)
        at riemann_flapjack_output.core$fn__14373.invoke(core.clj:20)
        at clojure.core$comp$fn__4196.doInvoke(core.clj:2419)
        at clojure.lang.RestFn.invoke(RestFn.java:408)
        at riemann_flapjack_output.core.RedisFlusherService.send_event(core.clj:68)
        at riemann_flapjack_output.core$eval14414$fn__14415$G__14406__14418.invoke(core.clj:48)
        at riemann_flapjack_output.core$eval14414$fn__14415$G__14405__14422.invoke(core.clj:48)
        at clojure.lang.AFn.applyToHelper(AFn.java:156)
        at clojure.lang.AFn.applyTo(AFn.java:144)
        at clojure.core$apply.invoke(core.clj:626)
        at clojure.core$partial$fn__4228.doInvoke(core.clj:2468)
        at clojure.lang.RestFn.invoke(RestFn.java:408)
        at riemann.config$eval15144$stream__15150$fn__15155.invoke(default.config:8)
        at riemann.config$eval15144$stream__15150.invoke(default.config:8)
        at riemann.core$stream_BANG_$fn__5727.invoke(core.clj:19)
        at riemann.core$stream_BANG_.invoke(core.clj:18)
        at riemann.core$instrumentation_service$measure__5736.invoke(core.clj:57)
        at riemann.service.ThreadService$thread_service_runner__3283$fn__3284.invoke(service.clj:71)
        at riemann.service.ThreadService$thread_service_runner__3283.invoke(service.clj:70)
        at clojure.lang.AFn.run(AFn.java:22)
        at java.lang.Thread.run(Thread.java:745)
```

This patch casts :perfdata to a float so that integers will be formatted properly by the format call.
